### PR TITLE
Fix outdated build script 

### DIFF
--- a/.github/workflows/pontoon-tarball.yml
+++ b/.github/workflows/pontoon-tarball.yml
@@ -42,7 +42,7 @@ jobs:
           ./make-pontoon-tarball.sh
 
       - name: "Upload artifacts"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: pontoon-release-tarball
           path: ./dist/
@@ -85,7 +85,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: "Download Pontoon release tarball"
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: pontoon-release-tarball
 

--- a/.github/workflows/pontoon-tarball.yml
+++ b/.github/workflows/pontoon-tarball.yml
@@ -26,10 +26,11 @@ jobs:
       - name: "Checkout the repository"
         uses: actions/checkout@v4
 
-      - name: "Set up Python 3.11"
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Set up Python 3.11
+        run: uv python install 3.11
 
       - name: "Set up Node 16"
         uses: actions/setup-node@v4

--- a/.github/workflows/pontoon-tarball.yml
+++ b/.github/workflows/pontoon-tarball.yml
@@ -103,6 +103,8 @@ jobs:
       - name: "Install Python dependencies"
         run: |
           cd pontoon-*
+          python -m pip install pip-tools
+          pip-compile --generate-hashes requirements/default.in -o requirements/default.txt
           pip install -r requirements.txt
 
       - name: "Make DB Migration"

--- a/.github/workflows/pontoon-tarball.yml
+++ b/.github/workflows/pontoon-tarball.yml
@@ -32,10 +32,10 @@ jobs:
       - name: Set up Python 3.11
         run: uv python install 3.11
 
-      - name: "Set up Node 16"
+      - name: "Set up Node 20"
         uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 20
 
       - name: "Make Pontoon release tarball"
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,17 @@
-FROM ubuntu:22.04
+FROM python:3.11-bookworm
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update && \
-    apt-get install -y \
-        build-essential \
-        ca-certificates \
-        curl \
-        git \
-        gnupg \
-        libpq-dev \
-        python3 \
-        python3-dev \
-        python3-venv \
-        && \
-    mkdir -p /etc/apt/keyrings && \
+RUN mkdir -p /etc/apt/keyrings && \
     curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
     echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list && \
     apt-get update && \
-    apt-get install -y nodejs
+    apt-get install -y \
+        build-essential \
+        git \
+        libpq-dev \
+        nodejs
 
 WORKDIR /data
 

--- a/debian/requirements.py310.in
+++ b/debian/requirements.py310.in
@@ -1,0 +1,10 @@
+# This file must be copied to the root of the Pontoon's repository,
+# Then the requirements.py310.txt can be generated with the following command:
+#
+#     uv pip compile --generate-hashes requirements.py310.in -o requirements.py310.txt
+#
+
+-r requirements.txt
+
+# Python 3.10 additional dependency for anyio
+exceptiongroup==1.2.2

--- a/make-pontoon-tarball.sh
+++ b/make-pontoon-tarball.sh
@@ -37,6 +37,9 @@ git checkout $PONTOON_REV
 uv --version > /dev/null 2>&1 && uv venv __env__ || python3 -m venv __env__
 source __env__/bin/activate
 
+# Collect info about the environment
+PYTHON_MAJOR=$(python -c "import sys;print(sys.version_info.major)")
+PYTHON_MINOR=$(python -c "import sys;print(sys.version_info.minor)")
 uv --version > /dev/null 2>&1 && UV_AVAILABLE=1 || UV_AVAILABLE=0
 
 # Install uv in the venv if not available
@@ -52,6 +55,9 @@ uv pip compile --generate-hashes requirements/test.in -o requirements/test.txt
 
 # Install Python dependencies
 uv pip install -r requirements.txt
+if [ $PYTHON_MAJOR == 3 ] && [ $PYTHON_MINOR -ge 12 ] ; then
+    uv pip install setuptools
+fi
 
 # Install Node dependencies
 npm install

--- a/make-pontoon-tarball.sh
+++ b/make-pontoon-tarball.sh
@@ -66,11 +66,9 @@ deactivate
 # Copy files
 cp -vr static/ $OUTPUT_DIR
 cp -vr pontoon/ $OUTPUT_DIR
-cp -vr tag-admin/ $OUTPUT_DIR
 cp -vr translate/ $OUTPUT_DIR
 cp -vr requirements/ $OUTPUT_DIR
 cp -v setup.py $OUTPUT_DIR
-cp -v setup.cfg $OUTPUT_DIR
 cp -v manage.py $OUTPUT_DIR
 cp -v requirements.txt $OUTPUT_DIR
 cp -v LICENSE $OUTPUT_DIR

--- a/make-pontoon-tarball.sh
+++ b/make-pontoon-tarball.sh
@@ -33,10 +33,19 @@ git clone https://github.com/mozilla/pontoon.git $BUILD_DIR/$APP_NAME.git
 cd $BUILD_DIR/$APP_NAME.git
 git checkout $PONTOON_REV
 
-# Install Python dependencies
+# Prepare Python Virtual Environment
 python3 -m venv __env__
 source __env__/bin/activate
 pip install --upgrade pip==23.1.1  # Pip version fixed because it breaks pip-tools everytime...
+pip install pip-tools # Required for pip-compile
+
+# Compile dependencies (Replicating: https://github.com/mozilla/pontoon/blob/d619331f62b28fd69d3f998d97e4343dd0ed6bc4/docker/compile_requirements.sh)
+pip-compile --generate-hashes requirements/default.in -o requirements/default.txt
+pip-compile --generate-hashes requirements/dev.in -o requirements/dev.txt
+pip-compile --generate-hashes requirements/lint.in -o requirements/lint.txt
+pip-compile --generate-hashes requirements/test.in -o requirements/test.txt
+
+# Install Python dependencies
 pip install -r requirements.txt
 
 # Install Node dependencies

--- a/make-pontoon-tarball.sh
+++ b/make-pontoon-tarball.sh
@@ -53,6 +53,10 @@ uv pip compile --generate-hashes requirements/dev.in -o requirements/dev.txt
 uv pip compile --generate-hashes requirements/lint.in -o requirements/lint.txt
 uv pip compile --generate-hashes requirements/test.in -o requirements/test.txt
 
+# Compile additional dependencies for Python 3.10
+cp $DEBIAN_DIR/requirements.py310.in $BUILD_DIR/$APP_NAME.git/
+uv pip compile --generate-hashes $BUILD_DIR/$APP_NAME.git/requirements.py310.in -o $OUTPUT_DIR/requirements.py310.txt
+
 # Install Python dependencies
 uv pip install -r requirements.txt
 if [ $PYTHON_MAJOR == 3 ] && [ $PYTHON_MINOR -ge 12 ] ; then

--- a/make-pontoon-tarball.sh
+++ b/make-pontoon-tarball.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Dependencies: build-essential git uv python3 python3-dev python3-venv nodejs npm
+# Dependencies: build-essential git python3 python3-dev python3-venv nodejs npm
 # Usage: ./make-pontoon-tarball.sh [PONTOON_REV [VERSION]]
 #  PONTOON_REV: Pontoon's revision (git) to release (default: main)
 #  VERSION: The version of the Pontoon Debian release (default: date +%Y.%m.%d.0)
@@ -33,9 +33,16 @@ git clone https://github.com/mozilla/pontoon.git $BUILD_DIR/$APP_NAME.git
 cd $BUILD_DIR/$APP_NAME.git
 git checkout $PONTOON_REV
 
-# Prepare Python Virtual Environment
-uv venv __env__
+# Prepare Python Virtual Environment using uv if available else using venv
+uv --version > /dev/null 2>&1 && uv venv __env__ || python3 -m venv __env__
 source __env__/bin/activate
+
+uv --version > /dev/null 2>&1 && UV_AVAILABLE=1 || UV_AVAILABLE=0
+
+# Install uv in the venv if not available
+if [ $UV_AVAILABLE != 1 ] ; then
+   pip install uv
+fi
 
 # Compile dependencies (Replicating: https://github.com/mozilla/pontoon/blob/d619331f62b28fd69d3f998d97e4343dd0ed6bc4/docker/compile_requirements.sh)
 uv pip compile --generate-hashes requirements/default.in -o requirements/default.txt

--- a/make-pontoon-tarball.sh
+++ b/make-pontoon-tarball.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Dependencies: build-essential git python3 python3-dev python3-venv nodejs npm
+# Dependencies: build-essential git uv python3 python3-dev python3-venv nodejs npm
 # Usage: ./make-pontoon-tarball.sh [PONTOON_REV [VERSION]]
 #  PONTOON_REV: Pontoon's revision (git) to release (default: main)
 #  VERSION: The version of the Pontoon Debian release (default: date +%Y.%m.%d.0)
@@ -34,19 +34,17 @@ cd $BUILD_DIR/$APP_NAME.git
 git checkout $PONTOON_REV
 
 # Prepare Python Virtual Environment
-python3 -m venv __env__
+uv venv __env__
 source __env__/bin/activate
-pip install --upgrade pip==23.1.1  # Pip version fixed because it breaks pip-tools everytime...
-pip install pip-tools # Required for pip-compile
 
 # Compile dependencies (Replicating: https://github.com/mozilla/pontoon/blob/d619331f62b28fd69d3f998d97e4343dd0ed6bc4/docker/compile_requirements.sh)
-pip-compile --generate-hashes requirements/default.in -o requirements/default.txt
-pip-compile --generate-hashes requirements/dev.in -o requirements/dev.txt
-pip-compile --generate-hashes requirements/lint.in -o requirements/lint.txt
-pip-compile --generate-hashes requirements/test.in -o requirements/test.txt
+uv pip compile --generate-hashes requirements/default.in -o requirements/default.txt
+uv pip compile --generate-hashes requirements/dev.in -o requirements/dev.txt
+uv pip compile --generate-hashes requirements/lint.in -o requirements/lint.txt
+uv pip compile --generate-hashes requirements/test.in -o requirements/test.txt
 
 # Install Python dependencies
-pip install -r requirements.txt
+uv pip install -r requirements.txt
 
 # Install Node dependencies
 npm install
@@ -58,7 +56,7 @@ export DJANGO_DEBUG=True
 
 # Build the front
 npm run build:prod
-python3 manage.py collectstatic
+uv run manage.py collectstatic
 
 # Leave the virtualenv
 deactivate


### PR DESCRIPTION
## What does this MR do and why?

This merge request resolves issues with the build process by addressing two key areas:
1. **Fixed dependency hashing**: Implemented proper dependency hashing using `uv` & `pip compile` to ensure reliable dependency management. (Replicating: [mozilla/pontoon:docker/compile_requirements.sh (#d619331f)](https://github.com/mozilla/pontoon/blob/d619331f62b28fd69d3f998d97e4343dd0ed6bc4/docker/compile_requirements.sh))
2. **Removed obsolete `cp` commands**: Removed file `cp` operations from the build script for files that are no longer present in the upstream Pontoon repository due to recent refactoring. This prevents build failures related to missing files.
https://github.com/mozilla/pontoon/pull/3367
 https://github.com/mozilla/pontoon/pull/3379
3. **Bump Artifact management workflows**: Github Actions have deprecated the `v3` upload/download artifact workflows, scheduling them for removal on 2025-01-30, To save the pipelines failing again in 2 months, lets sort that now, might as well :) (*Ref: [[Github Blog] Deprecation notice v3 of the artifact actions](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/)*)

These changes allow the build to complete successfully, resolving errors related to uncompiled dependencies or attempts to copy non-existent files.

## How to set up and validate locally
1. Clone the repository:
   ```bash
   git clone <repo_url>
   cd <repo_directory>
   ```

2. Run the build scripts:
   - `make-pontoon-tarball.sh`
   - `make-pontoon-tarball-docker.sh`

3. Validate the results:
   - Ensure that the tarballs are generated and present in the `dist/` directory.

---

Adjustments tested locally and both raw env and docker env builds are succeeding.

Ref Issue: https://github.com/wanadev/pontoon-debian/issues/9