### PR TITLE
add all commands for scheduled jobs

### DIFF
--- a/debian/clear-old-sync-logs.sh
+++ b/debian/clear-old-sync-logs.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+
+export DOTENV_PATH=/etc/opt/pontoon.env
+export LANG=c
+
+cd /opt/pontoon/current
+source __env__/bin/activate
+
+python manage.py clear_old_sync_logs
+
+deactivate

--- a/debian/clear-sessions.sh
+++ b/debian/clear-sessions.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+
+export DOTENV_PATH=/etc/opt/pontoon.env
+export LANG=c
+
+cd /opt/pontoon/current
+source __env__/bin/activate
+
+python manage.py clearsessions
+
+deactivate

--- a/debian/collect-insights.sh
+++ b/debian/collect-insights.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+
+export DOTENV_PATH=/etc/opt/pontoon.env
+export LANG=c
+
+cd /opt/pontoon/current
+source __env__/bin/activate
+
+python manage.py collect_insights
+
+deactivate

--- a/debian/send-deadline-notifications.sh
+++ b/debian/send-deadline-notifications.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+
+export DOTENV_PATH=/etc/opt/pontoon.env
+export LANG=c
+
+cd /opt/pontoon/current
+source __env__/bin/activate
+
+python manage.py send_deadline_notifications
+
+deactivate

--- a/debian/send-review-notifications.sh
+++ b/debian/send-review-notifications.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+
+export DOTENV_PATH=/etc/opt/pontoon.env
+export LANG=c
+
+cd /opt/pontoon/current
+source __env__/bin/activate
+
+python manage.py send_review_notifications
+
+deactivate

--- a/debian/send-suggestion-notifications.sh
+++ b/debian/send-suggestion-notifications.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+
+export DOTENV_PATH=/etc/opt/pontoon.env
+export LANG=c
+
+cd /opt/pontoon/current
+source __env__/bin/activate
+
+python manage.py send_suggestion_notifications
+
+deactivate

--- a/debian/warmup-cache.sh
+++ b/debian/warmup-cache.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+
+export DOTENV_PATH=/etc/opt/pontoon.env
+export LANG=c
+
+cd /opt/pontoon/current
+source __env__/bin/activate
+
+python manage.py warmup_cache
+
+deactivate

--- a/manual/install/cron.rst
+++ b/manual/install/cron.rst
@@ -21,6 +21,12 @@ run the synchronization every hour::
 For more information, read `the crontab documentation
 <https://www.man7.org/linux/man-pages/man5/crontab.5.html>`_.
 
+You can also fetch other tasks mentioned on the `Pontoon documentation
+<https://github.com/mozilla/pontoon/blob/main/docs/admin/deployment.rst#scheduled-jobs>`_.
+For example, to have insights be fetched at the start of each day::
+
+    0 6 * * * /opt/pontoon/current/debian/collect-insights.sh
+
 Once done, you can leave from the ``pontoon`` shell using the ``exit`` command.
 
 .. NOTE::


### PR DESCRIPTION
I added all commands mentioned on the [deployment guide](https://github.com/mozilla/pontoon/blob/main/docs/admin/deployment.rst).
i didnt make a single command that can run any argument as i was a little scared of having a root owned file with executable permissions doing such a thing.